### PR TITLE
Error when pip install pickle. It is already in PY

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 numpy
 nltk
-pickle
 gensim
 sklearn
 keras


### PR DESCRIPTION
Similar to: https://stackoverflow.com/questions/48477949/not-able-to-pip-install-pickle-in-python-3-6